### PR TITLE
ci(release.yml): add GitHub App token generation for enhanced security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: 'Generate token'
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
       - run: corepack enable
         name: Enable Corepack
 
@@ -32,5 +41,5 @@ jobs:
       - name: Release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: pnpm run release


### PR DESCRIPTION
Add a step to generate a GitHub App token using tibdex/github-app-token@v1. This improves security by using a GitHub App for authentication instead of a personal access token. Also, set fetch-depth to 0 in the checkout step to ensure the full history is fetched, which is necessary for some release tools.